### PR TITLE
Fix-class-fas-fa-copy

### DIFF
--- a/app/templates/lists/edit.html
+++ b/app/templates/lists/edit.html
@@ -332,6 +332,7 @@
 {% endblock %}
 
 {% block extra_js %}
+<script src="{{ url_for('static', filename='js/clipboard.min.js') }}"></script>
 <script>
 document.addEventListener('DOMContentLoaded', function() {
     // --- FORM SUBMISSION LOGIC ---

--- a/app/templates/lists/edit.html
+++ b/app/templates/lists/edit.html
@@ -238,7 +238,7 @@
                 <button type="button" class="btn btn-outline-secondary copy-btn" data-clipboard-text="{{ url_for('public_files_bp.get_public_csv', token=list.public_access_token, _external=True) }}" title="{{ _('Copy') }}"><i class="fas fa-copy"></i></button>
             {% else %}
                 <input type="text" class="form-control" readonly disabled value="{{ _('URL générée après enregistrement') }}">
-                <button type="button" class="btn btn-outline-secondary copy-btn" disabled title="Copier"><i class="fas fa-copy"></i></button>
+                <button type="button" class="btn btn-outline-secondary copy-btn" disabled title="{{ _('Copy') }}"><i class="fas fa-copy"></i></button>
             {% endif %}
         </div>
     </div>
@@ -250,7 +250,7 @@
                 <button type="button" class="btn btn-outline-secondary copy-btn" data-clipboard-text="{{ url_for('public_files_bp.get_public_txt', token=list.public_access_token, _external=True) }}" title="{{ _('Copy') }}"><i class="fas fa-copy"></i></button>
             {% else %}
                 <input type="text" class="form-control" readonly disabled value="{{ _('URL générée après enregistrement') }}">
-                <button type="button" class="btn btn-outline-secondary copy-btn" disabled title="Copier"><i class="fas fa-copy"></i></button>
+                <button type="button" class="btn btn-outline-secondary copy-btn" disabled title="{{ _('Copy') }}"><i class="fas fa-copy"></i></button>
             {% endif %}
         </div>
     </div>
@@ -262,7 +262,7 @@
                 <button type="button" class="btn btn-outline-secondary copy-btn" data-clipboard-text="{{ url_for('public_files_bp.get_public_json', token=list.public_access_token, _external=True) }}" title="{{ _('Copy') }}"><i class="fas fa-copy"></i></button>
             {% else %}
                 <input type="text" class="form-control" readonly disabled value="{{ _('URL générée après enregistrement') }}">
-                <button type="button" class="btn btn-outline-secondary copy-btn" disabled title="Copier"><i class="fas fa-copy"></i></button>
+                <button type="button" class="btn btn-outline-secondary copy-btn" disabled title="{{ _('Copy') }}"><i class="fas fa-copy"></i></button>
             {% endif %}
         </div>
     </div>


### PR DESCRIPTION
#fix(frontend): add explicit ClipboardJS script inclusion for public URL copy buttons

-ClipboardJS was not loaded on edit.html, preventing the copy-to-clipboard feature from working for public access URLs. This commit adds an explicit <script> tag for clipboard.min.js before the custom JS initialization, ensuring the feature works reliably. Also verified that no other copy method was present in the template.
