### PR TITLE
Fix-tokens-page-error-500

### DIFF
--- a/app/templates/api_tokens/index.html
+++ b/app/templates/api_tokens/index.html
@@ -38,17 +38,17 @@
                     {% for token in tokens %}
                     <tr>
                         <td>{{ token.name }}</td>
-                        <td>{{ token.created_at|datetime }}</td>
+                        <td>{{ token.created_at.strftime('%Y-%m-%d %H:%M:%S') if token.created_at else '' }}</td>
                         <td>
                             {% if token.expires_at %}
-                                {{ token.expires_at|datetime }}
+                                {{ token.expires_at.strftime('%Y-%m-%d %H:%M:%S') if token.expires_at else '' }}
                             {% else %}
                                 <span class="badge bg-info">{{ _('No expiration') }}</span>
                             {% endif %}
                         </td>
                         <td>
                             {% if token.last_used_at %}
-                                {{ token.last_used_at|datetime }}
+                                {{ token.last_used_at.strftime('%Y-%m-%d %H:%M:%S') if token.last_used_at else '' }}
                             {% else %}
                                 <span class="text-muted">{{ _('Never used') }}</span>
                             {% endif %}

--- a/app/templates/api_tokens/token_display.html
+++ b/app/templates/api_tokens/token_display.html
@@ -42,9 +42,9 @@
             </div>
             
             <div class="d-flex justify-content-between small text-muted mt-3">
-                <span><i class="fas fa-calendar-alt me-1"></i> {{ _('Created on:') }} {{ token_created_at|datetime }}</span>
+                <span><i class="fas fa-calendar-alt me-1"></i> {{ _('Created on:') }} {{ token_created_at.strftime('%Y-%m-%d %H:%M:%S') if token_created_at else '' }}</span>
                 {% if token_expires_at %}
-                <span><i class="fas fa-hourglass-end me-1"></i> {{ _('Expires on:') }} {{ token_expires_at|datetime }}</span>
+                <span><i class="fas fa-hourglass-end me-1"></i> {{ _('Expires on:') }} {{ token_expires_at.strftime('%Y-%m-%d %H:%M:%S') if token_expires_at else '' }}</span>
                 {% endif %}
             </div>
         </div>


### PR DESCRIPTION
## 🛠️ Fixes for API Token Management (admin)

### Issues Fixed

- **500 error on the token administration page (`/tokens`)**  
  The page failed due to the use of the Jinja2 `|datetime` filter, which does not exist in the project's Flask/Jinja2 environment.
- **500 error when creating and displaying a new token**  
  The confirmation template also used the `|datetime` filter to display the token's creation and expiration dates, causing a crash during generation.

### Solutions Applied

- **Replaced the `|datetime` filter**  
  All uses of the Jinja2 `|datetime` filter have been replaced with explicit Python `.strftime('%Y-%m-%d %H:%M:%S')` formatting in the templates:
  - [app/templates/api_tokens/index.html](cci:7://file:///c:/Users/Maneox/Documents/Projets%20de%20dev/List-IQ/app/templates/api_tokens/index.html:0:0-0:0)
  - [app/templates/api_tokens/token_display.html](cci:7://file:///c:/Users/Maneox/Documents/Projets%20de%20dev/List-IQ/app/templates/api_tokens/token_display.html:0:0-0:0)
- **Robust date display**  
  Token creation, expiration, and last usage dates are now displayed correctly, even if the value is missing.

### Tests

- The `/tokens` page now loads correctly, listing all tokens and their dates without error.
- Creating a new token works, the confirmation page displays without a 500 error, and the dates are readable.