### PR TITLE
Fix-display-options-Public-acces-TXT-format

### DIFF
--- a/app/templates/lists/edit.html
+++ b/app/templates/lists/edit.html
@@ -237,7 +237,7 @@
                 <input type="text" class="form-control" readonly value="{{ url_for('public_files_bp.get_public_csv', token=list.public_access_token, _external=True) }}">
                 <button type="button" class="btn btn-outline-secondary copy-btn" data-clipboard-text="{{ url_for('public_files_bp.get_public_csv', token=list.public_access_token, _external=True) }}" title="{{ _('Copy') }}"><i class="fas fa-copy"></i></button>
             {% else %}
-                <input type="text" class="form-control" readonly disabled value="{{ _('URL générée après enregistrement') }}">
+                <input type="text" class="form-control" readonly disabled value="{{ _('URL generated after registration') }}">
                 <button type="button" class="btn btn-outline-secondary copy-btn" disabled title="{{ _('Copy') }}"><i class="fas fa-copy"></i></button>
             {% endif %}
         </div>
@@ -249,7 +249,7 @@
                 <input type="text" class="form-control" readonly value="{{ url_for('public_files_bp.get_public_txt', token=list.public_access_token, _external=True) }}">
                 <button type="button" class="btn btn-outline-secondary copy-btn" data-clipboard-text="{{ url_for('public_files_bp.get_public_txt', token=list.public_access_token, _external=True) }}" title="{{ _('Copy') }}"><i class="fas fa-copy"></i></button>
             {% else %}
-                <input type="text" class="form-control" readonly disabled value="{{ _('URL générée après enregistrement') }}">
+                <input type="text" class="form-control" readonly disabled value="{{ _('URL generated after registration') }}">
                 <button type="button" class="btn btn-outline-secondary copy-btn" disabled title="{{ _('Copy') }}"><i class="fas fa-copy"></i></button>
             {% endif %}
         </div>
@@ -261,7 +261,7 @@
                 <input type="text" class="form-control" readonly value="{{ url_for('public_files_bp.get_public_json', token=list.public_access_token, _external=True) }}">
                 <button type="button" class="btn btn-outline-secondary copy-btn" data-clipboard-text="{{ url_for('public_files_bp.get_public_json', token=list.public_access_token, _external=True) }}" title="{{ _('Copy') }}"><i class="fas fa-copy"></i></button>
             {% else %}
-                <input type="text" class="form-control" readonly disabled value="{{ _('URL générée après enregistrement') }}">
+                <input type="text" class="form-control" readonly disabled value="{{ _('URL generated after registration') }}">
                 <button type="button" class="btn btn-outline-secondary copy-btn" disabled title="{{ _('Copy') }}"><i class="fas fa-copy"></i></button>
             {% endif %}
         </div>
@@ -573,11 +573,15 @@ document.addEventListener('DOMContentLoaded', function() {
         }
     }
     
-    document.getElementById('public_csv_enabled').addEventListener('change', togglePublicCsvHeadersOption);
-    togglePublicCsvHeadersOption();
-
-    // Correction affichage TXT public : togglePublicAccess sur le changement de la case TXT
+    // Harmonisation : chaque case Public Access a son listener pour afficher/masquer ses options
+    document.getElementById('public_csv_enabled').addEventListener('change', () => {
+        togglePublicCsvHeadersOption();
+        togglePublicAccess();
+    });
     document.getElementById('public_txt_enabled').addEventListener('change', togglePublicAccess);
+    document.getElementById('public_json_enabled').addEventListener('change', togglePublicAccess);
+    // Appels initiaux pour synchroniser l'état au chargement
+    togglePublicCsvHeadersOption();
     togglePublicAccess();
 
     // --- CLIPBOARDJS LOGIC ---

--- a/app/templates/lists/edit.html
+++ b/app/templates/lists/edit.html
@@ -576,6 +576,10 @@ document.addEventListener('DOMContentLoaded', function() {
     document.getElementById('public_csv_enabled').addEventListener('change', togglePublicCsvHeadersOption);
     togglePublicCsvHeadersOption();
 
+    // Correction affichage TXT public : togglePublicAccess sur le changement de la case TXT
+    document.getElementById('public_txt_enabled').addEventListener('change', togglePublicAccess);
+    togglePublicAccess();
+
     // --- CLIPBOARDJS LOGIC ---
         const DEBUG = JSON.parse('{{ debug_mode | tojson }}');
     function debugLog(...args) {


### PR DESCRIPTION
# Pull Request: Harmonize Public Access Export UI & English Translation

## Overview

This PR improves the List Settings page for public data exports (CSV, TXT, JSON):

- **Harmonizes the conditional display logic** for all public access export options.
  - Associated option blocks for CSV, TXT, and JSON are now shown/hidden immediately and consistently when toggled, matching the TXT section’s behavior.
- **Translates all placeholders** ("URL generated after registration") to English for CSV, TXT, and JSON export URLs, ensuring a fully English UI.

## Details

- Unified event listeners and initialization logic for all public access checkboxes (`public_csv_enabled`, `public_txt_enabled`, `public_json_enabled`).
- Refactored JavaScript so toggling any format’s checkbox updates the display of its related options and public URL field in real time.
- All export option blocks and their copy buttons now behave identically and intuitively for the user.
- All UI labels, placeholders, and tooltips are now in English.

## Testing

- Verified that all public access options (CSV, TXT, JSON) show/hide their settings and URLs correctly on toggle and after page reload.
- Confirmed that all UI elements are in English.

## Motivation

These changes provide a more consistent, user-friendly, and professional interface for managing public data exports, and ensure full English localization.